### PR TITLE
fix(loader): translations for france

### DIFF
--- a/src/locales/fr-fr.ts
+++ b/src/locales/fr-fr.ts
@@ -102,13 +102,13 @@ const frFR: Partial<Locale> = {
     skipLinkLabel: () => "Passer au contenu principal",
   },
   loader: {
-    loading: () => "Téléhargement",
+    loading: () => "Chargement en cours",
   },
   loaderSpinner: {
-    loading: () => "Téléhargement...",
+    loading: () => "Chargement en cours...",
   },
   loaderStar: {
-    loading: () => "Téléhargement...",
+    loading: () => "Chargement en cours...",
   },
   menuFullscreen: {
     ariaLabels: { closeButton: () => "Fermer" },


### PR DESCRIPTION
### Proposed behaviour

When Reduce animation effects is activated, on en french site, the loader component displays the following text ‘Chargement en cours'.

### Current behaviour

When Reduce animation effects is activated, on en french site, the loader component displays the following text ‘Téléhargement'.
![image](https://github.com/user-attachments/assets/9f5a18f9-4fb3-4e95-ab16-88058e105bba)


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
